### PR TITLE
3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Blogging platform, designed for personal use
 
 [![Automatic tests level](https://apps.yunohost.org/badge/cilevel/pureblog)](https://ci-apps.yunohost.org/ci/apps/pureblog/)
 
-🛠️ Upstream PureBlog repository: <https://github.com/kevquirk/pureblog/>
+🛠️ Upstream PureBlog repository: <https://codeberg.org/kevquirk/pureblog>
 
 Pull request are welcome and should target the [`testing` branch](https://github.com/YunoHost-Apps/pureblog_ynh/tree/testing).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Blogging platform, designed for personal use
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://pureblog.org/)
-[![Version: 2.5.1~ynh1](https://img.shields.io/badge/Version-2.5.1~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/pureblog/)
+[![Version: 3.0.1~ynh1](https://img.shields.io/badge/Version-3.0.1~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/pureblog/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/pureblog"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -13,10 +13,10 @@ maintainers = ["eric_G"]
 
 [upstream]
 license = "LicenseRef-Pure-Blog-1"
-license_url = "https://github.com/kevquirk/pureblog/?tab=License-1-ov-file"
+license_url = "https://codeberg.org/kevquirk/pureblog/src/branch/main/LICENSE.md"
 website = "https://pureblog.org/"
 admindoc = "https://pureblog.org/docs"
-code = "https://github.com/kevquirk/pureblog/"
+code = "https://codeberg.org/kevquirk/pureblog"
 
 [integration]
 yunohost = ">= 12.1.39"
@@ -59,7 +59,7 @@ ram.runtime = "50M"
     url = "https://github.com/kevquirk/pureblog/archive/refs/tags/v2.5.1.tar.gz"
     sha256 = "cc85657899c50dac03b18f61e34d27aa7cddfe33c089297e6f23cdeb275c5e9a"
 
-    autoupdate.strategy = "latest_github_tag"
+    autoupdate.strategy = "latest_forgejo_release"
 
     [resources.system_user]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "PureBlog"
 description.en = "Blogging platform, designed for personal use"
 description.fr = "Plateforme de blog, conçue pour un usage personnel"
 
-version = "2.5.1~ynh1"
+version = "3.0.1~ynh1"
 
 maintainers = ["eric_G"]
 
@@ -56,8 +56,8 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/kevquirk/pureblog/archive/refs/tags/v2.5.1.tar.gz"
-    sha256 = "cc85657899c50dac03b18f61e34d27aa7cddfe33c089297e6f23cdeb275c5e9a"
+    url = "https://codeberg.org/kevquirk/pureblog/archive/v3.0.1.tar.gz"
+    sha256 = "5ba8010ada6cedd9163f91fcd4f53ad7690232a8840a35e671089e8113cd57a3"
 
     autoupdate.strategy = "latest_forgejo_release"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -19,7 +19,7 @@ ynh_app_setting_set_default --key=php_post_max_size --value=50M
 #=================================================
 ynh_script_progression "Upgrading source files..."
 
-ynh_setup_source --dest_dir="$install_dir" --full_replace --keep="config"
+ynh_setup_source --dest_dir="$install_dir" --full_replace --keep="config content data"
 
 #=================================================
 # REAPPLY SYSTEM CONFIGURATION

--- a/tests.toml
+++ b/tests.toml
@@ -21,3 +21,4 @@ test_format = 1.0
     # -------------------------------
     # Commits to test upgrade from
     # -------------------------------
+    test_upgrade_from.4a38549807873ee20db37bf4aeb11d63489094ae.name = "Upgrade from 2.5.1~1"


### PR DESCRIPTION
Upgrade to 3.0.1, cf release announcement: https://pureblog.org/upgrading-to-v300-and-moving-to-codeberg

Notable changes:

- upstream moved to Codeberg
- breaking changes in code structure (we'll keep the nuke entire site from orbit for now)